### PR TITLE
Modifica lista de partidos en HomePage para pantallas distintas a teléfonos celulares

### DIFF
--- a/src/Pages/HomePage.jsx
+++ b/src/Pages/HomePage.jsx
@@ -3,6 +3,7 @@ import TopFive from '../components/TopFive';
 import './styles/HomePage.css'
 import TopSixTable from '../components/TopSixTable';
 import { useEffect, useRef, useState } from 'react';
+import FixturePc from '../components/FixturePc/FixturePc';
 
 
 const HomePage = ({ fixtures }) => {
@@ -28,6 +29,12 @@ const HomePage = ({ fixtures }) => {
   return (
     <section className='home'>
       <section className='home__main'>
+        <div className='fixturepc__container'>
+          <div className='fixturepc__grouped-list'>
+           <FixturePc
+           fixtures={fixtures} />
+          </div>
+        </div>
         <div className="home__topfive-container">
           <span className='topfive__title'>Últimos partidos</span>
           <div className={`topfive__cards-container ${isScrollable ? 'scrollable' : ''}`} ref={containerRef}>

--- a/src/Pages/styles/HomePage.css
+++ b/src/Pages/styles/HomePage.css
@@ -20,8 +20,8 @@
     border-top: 0.29em solid #4E4C70;
     border-bottom: 0.29em solid #4E4C70;
     border-radius: 0.9em;
-    overflow: hidden;
     background-image: linear-gradient(to right,  #4CAF50, #4E4C70);
+    overflow-y: hidden;
 }
 .topfive__title {
     display: flex;
@@ -32,7 +32,7 @@
     background-image: linear-gradient(to right,  #4CAF50, #4E4C70);
     padding: 0.8em;
     font-size: 16px;
-
+    border-radius: 0.8em;
     color: white;
 }
 .topfive__cards-container{
@@ -41,6 +41,7 @@
     overflow-y: auto;
     height: 28em;
     z-index: 100;
+    overflow: hidden;
 }
 .topfive__button-container {
     display: flex;
@@ -69,7 +70,6 @@
     border-top: 0.29em solid #4E4C70;
     border-bottom: 0.29em solid #4E4C70;
     border-radius: 0.9em;
-    overflow: hidden;
     display: flex;
     flex-direction: column;
     background-image: linear-gradient(to right,  #4CAF50, #4e4c70fa);
@@ -84,6 +84,10 @@
     padding: 0.8em;
     font-size: 16px;
     color: white;
+    border-radius: 0.8em;
+}
+.toptable__table {
+    overflow-y: hidden;
 }
 .toptable__button-container {
     display: flex;

--- a/src/Pages/styles/HomePage.css
+++ b/src/Pages/styles/HomePage.css
@@ -11,10 +11,22 @@
 .home__main {
     display: flex;
     flex-direction: column;
+    align-items: center;
+    justify-content: center;
     gap: 1em; 
-
+    width: 100vw;
+}
+.fixturepc__container {
+    max-width: 65%;
+    background-color:  #4E4C70;
+    padding-top: 1em;
+}
+.fixturepc__grouped-list{
+    max-width: auto;
+    display: block;
 }
 .home__topfive-container {
+    display: none;
     width: 100%;
     height: auto;
     border-top: 0.29em solid #4E4C70;
@@ -110,7 +122,7 @@
 
 
 
-@media screen and (max-width: 430px){
+@media screen and (max-width: 589px){
     .home {
         display: flex;
         flex-direction: column;
@@ -122,11 +134,17 @@
         flex-direction: column;
         gap: 0.015em;
     }
+    /* ---FIXTURE PC ----*/
+    .fixturepc__container {
+        display: none;
+    }
+    /*-------*/
     .home__table {
         display: none;
     }
 
     .home__topfive-container {
+        display: block;
         width: 100%;
         height: 19em;
         border-top: 0.29em solid #4E4C70;

--- a/src/components/FixturePc/FixturePc.jsx
+++ b/src/components/FixturePc/FixturePc.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from 'react-router-dom';
+import MatchPcDetails from "./MatchPcDetails";
+import "./Styles/FixturePc.css"
+ 
+const PAGE_SIZE = 20;
+const FixturePc = ({ fixtures }) => {
+    
+      const [currentPage, setCurrentPage] = useState(1);
+      const [groupedFixtures, setGroupedFixtures] = useState({});
+      const navigate = useNavigate();
+
+      const groupFixturesByDate = (fixtures) => {
+        return fixtures.reduce((acc, fixture) => {
+          const date = fixture.fixture.date.split('T')[0]; // Extract only the date part
+          if (!acc[date]) {
+            acc[date] = [];
+          }
+          acc[date].push(fixture);
+          return acc;
+        }, {});
+      };
+
+      function renderizarFecha(fechaStr) {
+        const fecha = new Date(fechaStr);
+        const options = { day: 'numeric', month: 'long' };
+        return fecha.toLocaleDateString('es-ES', options);
+      }
+
+      useEffect(() => {
+        const grouped = groupFixturesByDate(fixtures);
+        setGroupedFixtures(grouped)
+      }, [fixtures]);
+     
+      const goToPage = (page) => {
+        setCurrentPage(page);
+      };
+    
+      const goToPreviousPage = () => {
+        setCurrentPage(currentPage - 1);
+      };
+    
+      const handleFixtureClick = (id) => {
+        navigate(`/fixture/${id}`);
+      }; 
+    
+      // Get the array of dates (keys of groupedFixtures (from the useState)) fro pagination
+      const dates = Object.keys(groupedFixtures);
+      const totalPages = Math.ceil(dates.length / PAGE_SIZE);
+    
+      // Calculate current page fixtures grouped by dates
+      const startIndex = (currentPage - 1) * PAGE_SIZE;
+      const endIndex = startIndex + PAGE_SIZE;
+      const currentPageDates = dates.slice(startIndex, endIndex);
+    
+    
+      return (
+        <div className="fixture-list">
+          <div className="list__title">
+            <h3>Partidos</h3>
+          </div> 
+          <div className="fixture__grouped-container">{
+            currentPageDates.map((date, index) => (
+            <div className="fixture__group-date"
+             key={index}>
+                <div className="fixture__title">
+                    <h3>Jugados el {renderizarFecha(date)}</h3>
+                </div>
+                <div className="fixture__match-container">
+                    {groupedFixtures[date].map((fixture, idx) => (
+                        <div className="single__match-card"
+                        key={idx}
+                        onClick={() => handleFixtureClick(fixture.fixture.id)}
+                        >
+                            <MatchPcDetails 
+                            fixture={fixture} />
+                        </div>
+                    ))} 
+                </div>
+            </div>
+          ))}
+          </div>
+          <div className="pagination">
+            <button className="btn-prev" onClick={goToPreviousPage} disabled={currentPage === 1}>
+               Anterior
+            </button>
+              <span className="pagination-span">{`Página ${currentPage} de ${totalPages}`}</span>
+              <button className="btn-next" onClick={() => goToPage(currentPage + 1)} disabled={currentPage === totalPages}>
+                Siguiente
+            </button>
+          </div>
+        </div>
+      );
+    }
+   
+export default FixturePc

--- a/src/components/FixturePc/MatchPcDetails.jsx
+++ b/src/components/FixturePc/MatchPcDetails.jsx
@@ -1,0 +1,44 @@
+import "./Styles/MatchPcDetails.css"
+const MatchPcDetails = ({ fixture }) => {
+
+    return (
+        <article className="fixture__details">
+            <section className="fixture__details-match">
+                <div className="fixture__teams-home">
+                    <div className="fixture__home-logo-goals">
+                        <span className="fixture__home-logo">
+                            <img src={fixture.teams.home.logo} alt="" />
+                        </span>
+                        <span className="fixture__home-goals">
+                            {fixture.goals.home}
+                        </span>
+                    </div>
+                    <span className="fixture__teams-home-name">
+                        {fixture.teams.home.name}
+                    </span>
+                </div>
+                <div className="fixture__status">
+                    <h3>VS</h3>
+                </div>
+                <div className="fixture__teams-away">
+                    <div className="fixture__away-logo-goals">
+                        <span className="fixture__away-goals">
+                            {fixture.goals.home}
+                        </span>
+                        <span className="fixture__away-logo">
+                            <img src={fixture.teams.away.logo} alt="" />
+                        </span>
+                    </div>
+                    <span className="fixture__teams-away-name">
+                        {fixture.teams.away.name}
+                    </span>
+                </div>
+            </section>
+
+
+        </article>
+    )
+}
+
+
+export default MatchPcDetails

--- a/src/components/FixturePc/Styles/FixturePc.css
+++ b/src/components/FixturePc/Styles/FixturePc.css
@@ -1,0 +1,129 @@
+
+.list__title {
+    background-color: #4E4C70;
+}
+/* This class contents the list of fixtures grouped, */
+.fixture__grouped-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2em;
+    background-color: #4E4C70;
+    height: 50em;
+    overflow-y: auto;
+}
+.fixture__grouped-container::-webkit-scrollbar {
+    width: 8px;
+}
+.fixture__grouped-container::-webkit-scrollbar-thumb {
+background-color: #4CAF50; /* Color of the scrollbar thumb */
+border-radius: 10px; /* Rounded corners for the scrollbar thumb */
+}
+
+.fixture__grouped-container::-webkit-scrollbar-track {
+background-color: #2E2C4A; /* Background color of the scrollbar track */
+}
+/*End of the scroll bar logic*/
+
+.fixture__group-date {
+    display: flex;
+    flex-direction: column;
+    width: 95%;
+    padding: 0.2em;
+    background-color: #2E2C4A; 
+}
+.fixture__title h3 {
+    margin: 0;
+    color: #dde0d1; /* Consistent text color */
+    
+  }
+.fixture__match-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.5em;
+    padding: 0.5em;
+}
+.single__match-card {
+    display: flex;
+    flex-direction: column;
+    flex: 1; 
+    min-width: 20em;
+    max-width: 32.8%;
+    transition: transform 0.2s, box-shadow 0.2s; /* Smooth transition */
+}
+
+.single__match-card:hover {
+  transform: scale(1.026);
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3); /* Hover effect */
+}
+
+/*---/// Media queries para to Responsive Match Card ///*/
+@media (max-width: 1630px) {
+  .single__match-card {
+      max-width: 49.5%; 
+  }
+}
+
+@media (max-width: 1097px) {
+  .fixture__match-container {
+    justify-content: center;
+  }
+  .single__match-card {
+      max-width: 90%;
+  }
+}
+
+@media (max-width: 600px) {
+  .single__match-card {
+      max-width: 100%;
+  }
+}
+/*end of responsive Match card*/
+
+/* PAGINACIÓN  */
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.8em;
+    background-image: linear-gradient(to right,  #4CAF50, #4E4C70);
+    margin-top: 0.1em;
+  }
+  
+  .pagination-span {
+    margin: 0 1em;
+    font-size: 0.75rem;
+    color: #cdd3b7; /* Color de texto gris */
+  }
+  
+  .btn-prev,
+  .btn-next {
+    padding: 0.4em 0.8em;
+    font-size: 16px;
+    background-color: #c8d9df79; /* Color de fondo azul */
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s; /* Transición suave del color de fondo */
+  }
+  
+  .btn-prev:disabled,
+  .btn-next:disabled {
+    opacity: 0.5; /* Opacidad reducida para botones deshabilitados */
+    cursor: not-allowed; /* Cursor de no permitido para botones deshabilitados */
+  }
+  
+  .btn-prev:hover,
+  .btn-next:hover,
+  .btn-prev:focus,
+  .btn-next:focus {
+    background-color: #005f78; /* Cambio de color al pasar el mouse o al hacer clic */
+    outline: none; /* Quita el contorno al hacer clic en el botón */
+  }
+  .fixture__match-container {
+    cursor: pointer;
+  }

--- a/src/components/FixturePc/Styles/MatchPcDetails.css
+++ b/src/components/FixturePc/Styles/MatchPcDetails.css
@@ -1,0 +1,170 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
+
+.fixture__details {
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 10px;
+    background-color: white;
+    max-width: 100%;
+  }
+
+.fixture__details-match {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    background-color: white;
+}
+  
+  .fixture__teams-home,
+  .fixture__teams-away {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4em;
+    
+  }
+
+  .fixture__home-logo-goals {
+    display: flex;
+    flex-direction: row;
+  }
+  .fixture__away-logo-goals {
+    display: flex;
+    flex-direction: row;
+    width: 4em;
+    justify-content: space-between;
+  }
+  
+  .fixture__home-logo,
+  .fixture__away-logo {
+    margin-right: 10px;
+  }
+  
+  .fixture__home-logo img,
+  .fixture__away-logo img {
+    width: 2em; /* Tamaño ajustable según tus necesidades */
+    height: auto;
+  }
+  
+  .fixture__home-goals,
+  .fixture__away-goals {
+    font-weight: bold;
+    font-size: 1.5em;
+  }
+  
+  .fixture__status {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex-grow: 1;
+    text-align: center;
+    max-width: 16em;
+    gap: 0.3em;
+  }
+  
+  .fixture__status-status {
+    font-weight: bold;
+    margin: 0;
+  }
+  
+  .fixture__status-date {
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  @media screen and (max-width: 430px) {
+    .fixture__details {
+       padding: 5 10 0.3 10em;
+      }
+    
+    .fixture__details-match {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        justify-content: space-between;
+        
+    }
+      
+      .fixture__teams-home,
+      .fixture__teams-away {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.4em;
+        max-width: 4.8em;
+        min-width: 4.7em;
+      }
+    
+      .fixture__home-logo-goals {
+        display: flex;
+        width: 80%;
+        flex-direction: row;
+        align-items: start;
+      }
+      .fixture__away-logo-goals {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: 100%;
+        justify-content: flex-end;
+        align-items: end;
+      }
+      
+      /*.fixture__home-logo,*/
+      .fixture__away-logo {
+       display: flex;
+       flex-direction: row;
+       align-items: end;
+      }
+      .fixture__away-goals {
+        margin-right: 0.4em;
+      }
+      
+      .fixture__home-logo img,
+      .fixture__away-logo img {
+        width: 1.8em; /* Tamaño ajustable según tus necesidades */
+        height: auto;
+      }
+      
+      .fixture__home-goals,
+      .fixture__away-goals {
+        font-weight: bold;
+        font-size: 1.3em;
+      }
+
+      .fixture__teams-home-name {
+        display: flex;
+        flex-wrap: wrap;
+        text-align: center;
+        font-size: 0.9rem;
+        font-weight: 500;
+      }      
+      .fixture__teams-away-name {
+        display: flex;
+        flex-direction: row;
+        justify-content: end;
+        align-items: flex-end;
+        text-align: center;
+        font-size: 0.9rem;
+        font-weight: 500;
+        margin-right: 0.2em;
+      }   
+      .fixture__status {
+        text-align: center;
+        max-width: 16em;
+        gap: 0.3em;
+      }
+      
+      .fixture__status-status {
+        font-weight: bold;
+        font-size: 0.8rem;
+        margin: 0;
+      }
+      
+      .fixture__status-date {
+        font-size: 0.8em;
+        color: #666;
+      }
+  }

--- a/src/components/styles/TopSixTable.css
+++ b/src/components/styles/TopSixTable.css
@@ -2,7 +2,7 @@
 
 @media screen and (min-width: 431px) {
   .table__container {
-    overflow-x: auto;
+    overflow-y: hidden;
     max-width: 100%;
     height: 30em;
     margin: 0 auto;
@@ -10,7 +10,6 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    overflow-y:unset;
   }
   .table__section {
     width: 100%;


### PR DESCRIPTION
Se crean dos componentes FixturePc y MatcPcDetails para modificar el desplegado de la lista de partidos en HomePage en pantallas con ancho mayor a 590px. 

Se crean los respectivos archivos de estilo para cada componente y se añade lógica necesaria para renderizar los detalles de cada partido en MatchPcDetails, y resderizar este dentro de FixturePc. 

Así mismo, se reutiliza la lógica para paginación que se tiene en el componente FixtureList, con dos funciones más para mostrar los partidos agrupados por fecha y renderizar fecha en otro formato (respectivamente). Y se agrega lógica para scroll en eje-Y.